### PR TITLE
avoid using document in nodejs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,9 +94,11 @@ class AutoSnapshotSuite
 
     public getHTML(): string
     {
+      if(typeof document !== 'undefined') {
         document.body.style.fontFamily = "Courier New";
         document.body.style.whiteSpace = "nowrap";
-        if (!this.name) { throw "name not defined for snapshot suite"; }
+      }
+      if (!this.name) { throw "name not defined for snapshot suite"; }
 
         if (!this.hasFailure())
         {
@@ -206,7 +208,11 @@ jasmine.getEnv().addReporter({
                 return prev_html + "<br //>" + curr_suite.getHTML();
             }, "");
 
-        document.body.innerHTML = html_summary + document.body.innerHTML;
+        if(typeof document !== 'undefined') {
+          document.body.innerHTML = html_summary + document.body.innerHTML;
+        } else {
+          console.log(html_summary);
+        }
     }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,11 +94,11 @@ class AutoSnapshotSuite
 
     public getHTML(): string
     {
-      if(typeof document !== 'undefined') {
-        document.body.style.fontFamily = "Courier New";
-        document.body.style.whiteSpace = "nowrap";
-      }
-      if (!this.name) { throw "name not defined for snapshot suite"; }
+        if(typeof document !== 'undefined') {
+            document.body.style.fontFamily = "Courier New";
+            document.body.style.whiteSpace = "nowrap";
+        }
+        if (!this.name) { throw "name not defined for snapshot suite"; }
 
         if (!this.hasFailure())
         {
@@ -209,9 +209,9 @@ jasmine.getEnv().addReporter({
             }, "");
 
         if(typeof document !== 'undefined') {
-          document.body.innerHTML = html_summary + document.body.innerHTML;
+            document.body.innerHTML = html_summary + document.body.innerHTML;
         } else {
-          console.log(html_summary);
+            console.log(html_summary);
         }
     }
 });


### PR DESCRIPTION
This fix is for using snap shots in node js. 'document' is not defined in nodejs. So adding a check before using it. This solves the current problem of summary not being created for nodejs when tests fail as getHtml() throws an exception.